### PR TITLE
Added the IDeployable interface

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,3 @@
+# Deploy Tool
+
+This is a tool that allows a user to deploy a cosim to a given directory in order to run the cosimulation.

--- a/deploy/commands/README.md
+++ b/deploy/commands/README.md
@@ -1,0 +1,3 @@
+# `commands`
+
+This is the directory that contains the files that will constitude the Deploy tool command implementations.

--- a/deploy/plugins/README.md
+++ b/deploy/plugins/README.md
@@ -1,0 +1,3 @@
+# `interface`
+
+This directory directly contains the `IDeployable` interface class and the plugin manager class. Subdirectories will contain the actual plugin implementations.

--- a/deploy/plugins/interface.py
+++ b/deploy/plugins/interface.py
@@ -28,3 +28,4 @@ class IDeployable(abc.ABC):
     def get_name(self) -> str:
         """Returns the name of the Plugin (NOT the model). This is the unique identifier for the plugin.
         Be careful to give a specific enough name to prevent name collisions."""
+        pass

--- a/deploy/plugins/interface.py
+++ b/deploy/plugins/interface.py
@@ -1,0 +1,30 @@
+import abc
+import typing
+
+class IDeployable(abc.ABC):
+    @abc.abstractmethod
+    def deploy(self, json_config: dict, deploy_root: str, install_root: str) -> bool:
+        """Writes the plugin info to the corresponding deploy directory."""
+        pass
+
+    @abc.abstractmethod
+    def get_baseline_files(self, install_root: str) -> list[str]:
+        """Gets a list of filepaths for the baseline files. These files should NOT be modified by the user."""
+        pass
+
+    @abc.abstractmethod
+    def get_model_files(self, model_name: str, deploy_root: str) -> list[str]:
+        """Gets a list of filepaths that have been modified for model within the given deploy directory.
+        You may change any values in these files, but this does not guarantee that the cosim will still work."""
+        pass
+
+    @abc.abstractmethod
+    def get_exec_json(self, model_name: str, deploy_root: str) -> typing.Dict[str, typing.Any]:
+        """Returns a JSON object that represents a valid HELICS Runner file federate object.
+        Should contain the fields directory, exec, host, name."""
+        pass
+
+    @abc.abstractmethod
+    def get_name(self) -> str:
+        """Returns the name of the Plugin (NOT the model). This is the unique identifier for the plugin.
+        Be careful to give a specific enough name to prevent name collisions."""


### PR DESCRIPTION
There is nothing to run here, look at the interface implementation compared to the documentation.

I learned python has no traditional function overloading because of its dynamic typing, which makes sense. So I renamed the functions to be distinct from each other. And I decided to just have the name be given through a getter function.