### PR TITLE
24 add a way to get a list of plugin names from the deploy tool via a python command

### DIFF
--- a/deploy/commands/list_names.py
+++ b/deploy/commands/list_names.py
@@ -1,6 +1,9 @@
 import plugins.manager
 
-def print_plugin_names(manager: plugins.manager.PluginManager) -> None:
-    print("Printing IDeployable Plugin Name:")
-    for name in manager.get_plugin_names():
-        print(f"\t{name}")
+def get_plugin_names(manager: plugins.manager.PluginManager) -> str:
+    names = manager.get_plugin_names()
+    if not names:
+        return ""
+    else:
+        # We need to tab the first object as well
+        return "\t" + "\n\t".join(manager.get_plugin_names())

--- a/deploy/commands/list_names.py
+++ b/deploy/commands/list_names.py
@@ -1,0 +1,4 @@
+import plugins.manager
+
+def get_plugin_names(manager: plugins.manager.PluginManager) -> list[str]:
+    return manager.get_plugin_names()

--- a/deploy/commands/list_names.py
+++ b/deploy/commands/list_names.py
@@ -1,4 +1,6 @@
 import plugins.manager
 
-def get_plugin_names(manager: plugins.manager.PluginManager) -> list[str]:
-    return manager.get_plugin_names()
+def print_plugin_names(manager: plugins.manager.PluginManager) -> None:
+    print("Printing IDeployable Plugin Name:")
+    for name in manager.get_plugin_names():
+        print(f"\t{name}")

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -15,13 +15,16 @@ def main():
 
     try:
         # Initialize Plugins
-        plugins_dir = pathlib.Path(__file__, "plugins") # Safe way to get to plugins directory
+        plugins_dir = pathlib.Path(__file__).resolve().parent / "plugins" # Safe way to get to plugins directory
         plugin_manager = manager.PluginManager(plugins_dir)
 
         if args.command == "list-names":
-            commands.list_names.get_plugin_names()
+            commands.list_names.get_plugin_names(plugin_manager)
     except ValueError as e:
         print(str(e))
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        print(f"Exception type: {type(e).__name__}")
 
 if __name__ == '__main__':
     main()

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -9,7 +9,7 @@ def main():
     subparsers = top_parser.add_subparsers(dest="command", help="The Deploy Tool Commands")
 
     # list-names command
-    list_names_parser = subparsers.add_parser("list-names", help="List the names of the found IDeployable Plugins")
+    subparsers.add_parser("list-names", help="List the names of the found IDeployable Plugins")
 
     args = top_parser.parse_args()
 
@@ -19,7 +19,7 @@ def main():
         plugin_manager = manager.PluginManager(plugins_dir)
 
         if args.command == "list-names":
-            commands.list_names.get_plugin_names(plugin_manager)
+            commands.list_names.print_plugin_names(plugin_manager)
     except ValueError as e:
         print(str(e))
     except Exception as e:

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -4,6 +4,10 @@ import commands.list_names
 import pathlib
 import plugins.manager as manager
 
+def print_plugin_names(plugin_manager: manager.PluginManager) -> None:
+    print("IDeployable Plugin Names:")
+    print(commands.list_names.get_plugin_names(plugin_manager))
+
 def main():
     top_parser = argparse.ArgumentParser("UNCC Deploy Tool for initializing runnable cosimulation models")
     subparsers = top_parser.add_subparsers(dest="command", help="The Deploy Tool Commands")
@@ -19,7 +23,7 @@ def main():
         plugin_manager = manager.PluginManager(plugins_dir)
 
         if args.command == "list-names":
-            commands.list_names.print_plugin_names(plugin_manager)
+            print_plugin_names(plugin_manager)
     except ValueError as e:
         print(str(e))
     except Exception as e:

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -1,8 +1,18 @@
 import argparse
 
+import commands.list_names
+
 def main():
     top_parser = argparse.ArgumentParser("UNCC Deploy Tool for initializing runnable cosimulation models")
     subparsers = top_parser.add_subparsers(dest="command", help="The Deploy Tool Commands")
+
+    # list-names command
+    list_names_parser = subparsers.add_parser("list-names", help="List the names of the found IDeployable Plugins")
+
+    args = top_parser.parse_args()
+
+    if args.command == "list-names":
+        commands.list_names.get_plugin_names()
 
 if __name__ == '__main__':
     main()

--- a/deploy/plugins/manager.py
+++ b/deploy/plugins/manager.py
@@ -16,6 +16,7 @@ class PluginManager:
         try:
             # Create a full dotted module name
             module_name = self._get_module_name(file_path, plugin_root)
+            # print(f"\nPluginManager->_attempt_store->module_name: {module_name}")
 
             # Import the module
             # Using import_module ensures __package__ and parent hierarchy
@@ -41,6 +42,7 @@ class PluginManager:
         self._plugins = dict[str, interface.IDeployable]()
 
         plugin_root = plugin_directory.resolve()
+        # print(f"\nPluginManager->__init__->plugin_root: {plugin_root}")
         if not plugin_root.exists():
             raise ValueError(f"Plugin Directory does not exist: {plugin_root}")
         elif not plugin_root.is_dir():
@@ -48,8 +50,10 @@ class PluginManager:
 
         # The parent directory must be in sys.path for dotted imports to work
         parent_dir = str(plugin_root.parent)
+        # print(f"\nPluginManager->__init__->parent_dir: {parent_dir}")
         if parent_dir not in sys.path:
             sys.path.insert(0, parent_dir)
+        # print(f"\nPluginManager->__init__->sys.path: {sys.path}")
 
         try:
             # rglob("*.py") handles the recursion automatically
@@ -63,12 +67,20 @@ class PluginManager:
             # Clean up sys.path
             if parent_dir in sys.path:
                 sys.path.remove(parent_dir)
+            # print(f"\nPluginManager->__init__->sys.path: {sys.path}")
 
     def get(self, name: str) -> interface.IDeployable | None:
+        # print(f"\nplugin_manager->get({name})")
+        keys_string = ', '.join(str(key) for key in self._plugins)
+        # print(f"\nplugin_manager->_plugin->get_keys(): '{keys_string}'")
         if name in self._plugins:
+            # print(f"\nplugin_manager->get({name}): Key Found!")
             return self._plugins[name]
         else:
+            # print(f"\nplugin_manager->get({name}): Key Not Found!")
             return None
 
     def get_plugin_names(self) -> list[str]:
-        return list(self._plugins.keys())
+        keys_list = list(self._plugins.keys())
+        # print(f"\nplugin_manager->get_plugin_names() keys: '{keys_list}'")
+        return keys_list

--- a/deploy/tests/test_list_names.py
+++ b/deploy/tests/test_list_names.py
@@ -1,0 +1,30 @@
+import unittest.mock as mock
+
+import commands.list_names as list_names
+import plugins.manager as manager
+import tests.tools.base_plugin_manager_test_case as base_test
+
+class TestListNames(base_test.BaseTestPluginManager):
+    def test_get_plugin_names(self):
+        plugin_names = list_names.get_plugin_names(self.manager)
+        expected_string = "\tmock_plugin_a/interface\n\tmock_plugin_b/interface"
+
+        self.assertEqual(expected_string, plugin_names)
+
+    def test_get_plugin_names_single_name(self):
+        with mock.patch.object(manager.PluginManager, 'get_plugin_names') as mock_get_names:
+            mock_get_names.return_value = ["one_name"]
+
+            plugin_names = list_names.get_plugin_names(self.manager)
+            expected_string = "\tone_name"
+
+            self.assertEqual(expected_string, plugin_names)
+
+    def test_get_plugin_names_no_names(self):
+        with mock.patch.object(manager.PluginManager, 'get_plugin_names') as mock_get_names:
+            mock_get_names.return_value = []
+
+            plugin_names = list_names.get_plugin_names(self.manager)
+            expected_string = ""
+
+            self.assertEqual(expected_string, plugin_names)

--- a/deploy/tests/test_plugins_manager.py
+++ b/deploy/tests/test_plugins_manager.py
@@ -1,76 +1,22 @@
-import unittest
-import unittest.mock as mock
-import pathlib
-import typing
-
-import plugins.manager as manager
 import plugins.interface as interface
+import tests.tools.base_plugin_manager_test_case as base_test
 
-class TestInterfaceImplementation(interface.IDeployable):
-    def deploy(self, json_config: dict, deploy_root: str, install_root: str):
-        pass
-
-    def get_baseline_files(self, install_root: str) -> list[str]:
-        return [str(pathlib.Path(install_root, "test"))]
-
-    def get_model_files(self, model_name: str, deploy_root: str) -> list[str]:
-        return [str(pathlib.Path(deploy_root, model_name))]
-
-    def get_exec_json(self, model_name: str, deploy_root: str) -> typing.Dict[str, typing.Any]:
-        return {
-            "directory": ".",
-            "exec": "./test",
-            "host": "localhost",
-            "name": "test"
-        }
-
-    def get_name(self) -> str:
-        return "test/interface"
-
-class TestPluginManager(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        print("-" * 40)
-        print(f"\nStarting {cls.__name__}")
-        # Start the patches
-        cls.iter_patcher = mock.patch("pkgutil.iter_modules")
-        cls.import_patcher = mock.patch("importlib.import_module")
-        cls.mock_iter = cls.iter_patcher.start()
-        cls.mock_import = cls.import_patcher.start()
-
-        # Launch the test plugin
-        cls.TestPluginClass = TestInterfaceImplementation
-
-        # Configure the mocks
-        cls.mock_iter.return_value = [(None, "test_mod", False)]
-        mock_module = mock.MagicMock()
-        mock_module.TestPlugin = cls.TestPluginClass
-        cls.mock_import.return_value = mock_module
-
-        # Mock the path object
-        mock_path = mock.MagicMock(spec=pathlib.Path)
-        mock_path.exists.return_value = True
-        mock_path.__str__.return_value = "plugins"
-
-        # Instantiate the manager once
-        cls.manager = manager.PluginManager(mock_path)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.iter_patcher.stop()
-        cls.import_patcher.stop()
+class TestPluginManager(base_test.BaseTestPluginManager):
+    def test_manager_exists(self):
+        self.assertIsNotNone(self.manager)
 
     def test_get_plugin_names(self):
         actual_names = self.manager.get_plugin_names()
-        expected_names = ["test/interface"]
+        expected_names = ["mock_plugin_a/interface", "mock_plugin_b/interface"]
 
-        self.assertListEqual(expected_names, actual_names)
+        self.assertCountEqual(expected_names, actual_names)
 
     def test_get_name_exists(self):
-        plugin = self.manager.get("test/interface")
+        plugin = self.manager.get("mock_plugin_a/interface")
 
         self.assertIsNotNone(plugin)
         self.assertIsInstance(plugin, interface.IDeployable)
+        self.assertIsInstance(plugin, base_test.MockPluginA)
 
     def test_get_name_does_not_exist(self):
         plugin = self.manager.get("non_name")

--- a/deploy/tests/tools/base_plugin_manager_test_case.py
+++ b/deploy/tests/tools/base_plugin_manager_test_case.py
@@ -1,0 +1,131 @@
+import unittest
+import unittest.mock as mock
+import pathlib
+import typing
+
+import plugins.manager
+import plugins.interface
+
+class MockPluginA(plugins.interface.IDeployable):
+    def deploy(self, json_config: dict, deploy_root: str, install_root: str):
+        pass
+
+    def get_baseline_files(self, install_root: str) -> list[str]:
+        return [str(pathlib.Path(install_root, "mock_plugin_a"))]
+
+    def get_model_files(self, model_name: str, deploy_root: str) -> list[str]:
+        return [str(pathlib.Path(deploy_root, model_name))]
+
+    def get_exec_json(self, model_name: str, deploy_root: str) -> typing.Dict[str, typing.Any]:
+        return {
+            "directory": ".",
+            "exec": "./mock_plugin_a",
+            "host": "localhost",
+            "name": "mock_plugin_a"
+        }
+
+    def get_name(self) -> str:
+        return "mock_plugin_a/interface"
+
+class MockPluginB(plugins.interface.IDeployable):
+    def deploy(self, json_config: dict, deploy_root: str, install_root: str):
+        pass
+
+    def get_baseline_files(self, install_root: str) -> list[str]:
+        return [str(pathlib.Path(install_root, "mock_plugin_b"))]
+
+    def get_model_files(self, model_name: str, deploy_root: str) -> list[str]:
+        return [str(pathlib.Path(deploy_root, model_name))]
+
+    def get_exec_json(self, model_name: str, deploy_root: str) -> typing.Dict[str, typing.Any]:
+        return {
+            "directory": ".",
+            "exec": "./mock_plugin_b",
+            "host": "localhost",
+            "name": "mock_plugin_b"
+        }
+
+    def get_name(self) -> str:
+        return "mock_plugin_b/interface"
+
+class BaseTestPluginManager(unittest.TestCase):
+    manager: plugins.manager.PluginManager
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Mock the path object for rglob
+        cls.plugin_root = pathlib.Path("/fake/plugins")
+
+        # Create mock file objects that rglob will "find"
+        mock_file_a = mock.MagicMock(spec=pathlib.Path)
+        mock_file_a.name = "module_a.py"
+        mock_file_a.stem = "module_a"
+        mock_file_a.suffix = ".py"
+        # This needs to match the logic in _get_module_name
+        # relative_to(plugin_root.parent) -> plugins/module_a
+        mock_file_a.relative_to.return_value = pathlib.Path("plugins/module_a.py")
+        mock_file_a.parts = ("plugins", "module_a.py")
+
+        mock_file_b = mock.MagicMock(spec=pathlib.Path)
+        mock_file_b.name = "module_b.py"
+        mock_file_b.stem = "module_b"
+        mock_file_b.suffix = ".py"
+        mock_file_b.relative_to.return_value = pathlib.Path("plugins/module_b.py")
+        mock_file_b.parts = ("plugins", "module_b.py")
+
+        # Mock the directory itself
+        cls.mock_path = mock.MagicMock(spec=pathlib.Path)
+        cls.mock_path.resolve.return_value = cls.mock_path
+        cls.mock_path.exists.return_value = True
+        cls.mock_path.is_dir.return_value = True
+        cls.mock_path.parent = pathlib.Path("/fake")
+        cls.mock_path.rglob.return_value = [mock_file_a, mock_file_b]
+
+        # Update __module__ so the PluginManager doesn't filter them out
+        MockPluginA.__module__ = "plugins.module_a"
+        MockPluginB.__module__ = "plugins.module_b"
+
+        # Setup Mock Modules
+        cls.mock_module_a = mock.MagicMock()
+        cls.mock_module_a.PluginA = MockPluginA
+
+        cls.mock_module_b = mock.MagicMock()
+        cls.mock_module_b.PluginB = MockPluginB
+
+        # inspect.getmembers uses the __dict__ or dir()
+        cls.mock_module_a_members = [("PluginA", MockPluginA)]
+        cls.mock_module_b_members = [("PluginB", MockPluginB)]
+
+        # Patching
+        cls.import_patcher = mock.patch("importlib.import_module")
+        cls.inspect_patcher = mock.patch("inspect.getmembers")
+
+        cls.mock_import = cls.import_patcher.start()
+        cls.mock_inspect = cls.inspect_patcher.start()
+
+        def import_side_effect(name):
+            if name == 'plugins.module_a':
+                return cls.mock_module_a
+            elif name == 'plugins.module_b':
+                return cls.mock_module_b
+            else:
+                raise ImportError(f"Module {name} not found")
+
+        def inspect_side_effect(module, predicate=None):
+            if module == cls.mock_module_a:
+                return cls.mock_module_a_members
+            elif module == cls.mock_module_b:
+                return cls.mock_module_b_members
+            else:
+                return []
+
+        cls.mock_import.side_effect = import_side_effect
+        cls.mock_inspect.side_effect = inspect_side_effect
+
+        # Initialize the manager with our mocked path
+        cls.manager = plugins.manager.PluginManager(cls.mock_path)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.import_patcher.stop()
+        cls.inspect_patcher.stop()

--- a/deploy/tests/tools/base_plugin_test_case.py
+++ b/deploy/tests/tools/base_plugin_test_case.py
@@ -34,23 +34,23 @@ class BasePluginTestCase(unittest.TestCase):
     @classmethod
     def validate_install_dir(cls) -> None:
         install_path = cls._get_install_path()
-        print(f"Install Dir: {install_path}")
+        # print(f"Install Dir: {install_path}")
         if not install_path.exists():
             raise cls.failureException(f"Install Dir does not exist: {install_path}")
 
     @classmethod
     def validate_deploy_dir(cls) -> None:
         deploy_path = cls._get_safe_deployed_path()
-        print(f"Deploy Dir: {deploy_path}")
+        # print(f"Deploy Dir: {deploy_path}")
 
         deploy_path.mkdir(parents=True, exist_ok=True)
         cls._init_deployed_files(deploy_path)
 
     @classmethod
     def setUpClass(cls) -> None:
-        print("-" * 40)
-        print(f"Starting {cls.__name__}")
-        print(f"{cls.__name__} Install Dir: {cls.install_dir}")
+        # print("-" * 40)
+        # print(f"Starting {cls.__name__}")
+        # print(f"{cls.__name__} Install Dir: {cls.install_dir}")
         cls.validate_install_dir()
         cls.validate_deploy_dir()
-        print("-" * 40)
+        # print("-" * 40)


### PR DESCRIPTION
You should be able to test this manually by typing "python -m deploy --help" and following the guides from their. This is all under the root directory "deploy", and you will need to have previously built and installed the c++ federates.