### PR TITLE
25 add the deploy command to the deploy tool

### DIFF
--- a/deploy/commands/deploy_config.py
+++ b/deploy/commands/deploy_config.py
@@ -104,18 +104,51 @@ def _get_value_or_default(json_dict: dict[str, typing.Any], key: str, expected_t
     return value
 
 def _write_helics_json(cosim_def_file: pathlib.Path, manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> pathlib.Path:
+    # Get cosim name
     cosim_def_data = _get_json_data(cosim_def_file)
-
     cosim_name = cosim_def_data["cosim_name"]
 
+    # Initialize the federates
+    federates = list[dict[str, str]]()
+    models = _get_models(manager, deploy_root)
+    for plugin_name, model_names in models:
+        plugin = manager.get(plugin_name)
+        if not plugin:
+            continue # this should never happen
+
+        for model_name in model_names:
+            federates.append(plugin.get_exec_json(model_name, str(deploy_root)))
+
+    # Setup the broker
+    federate_count = len(models)
+    broker_federate = {
+        "directory": ".",
+        "exec": f"helics-broker --federates={federate_count} --port 23500",
+        "host": "localhost",
+        "name": "main_broker"
+    }
+    federates.insert(0, broker_federate)
+
+    # Setup helics json
     helics_json_data = dict()
     helics_json_data["name"] = cosim_name
+    helics_json_data["federates"] = federates
 
-def _get_models(manager: plugins.manager.PluginManager, json_data: dict[str, typing.Any]) -> dict[str, list[str]]:
+    # Write helics json data to the cosim directory
+    helics_runner_file = cosim_def_file.parent / "helics_runner.json"
+    with open(helics_runner_file, "w") as json_file:
+        json.dump(helics_json_data, json_file, indent=4)
+
+    return helics_runner_file
+
+def _get_models(manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> dict[str, list[str]]:
     models = dict[str, list[str]]()
 
-    components = _get_value_or_default(json_data, "components", list[dict[str, typing.Any]])
+    for plugin_name in manager.get_plugin_names():
+        plugin = manager.get(plugin_name)
+        if not plugin:
+            continue
+
+        models[plugin_name] = plugin.list_model_names(str(deploy_root))
 
     return models
-
-def

--- a/deploy/commands/deploy_config.py
+++ b/deploy/commands/deploy_config.py
@@ -13,8 +13,8 @@ def deploy(manager: plugins.manager.PluginManager, install_root: pathlib.Path, d
 
     json_data = _get_json_data(json_file)
 
-    _deploy_config(json_data, manager, install_root, deploy_root)
-    helics_json_file = _write_helics_json(manager, deploy_root)
+    cosim_def_file = _deploy_config(json_data, manager, install_root, deploy_root)
+    helics_json_file = _write_helics_json(cosim_def_file, manager, deploy_root)
 
     return f"Successfully deployed and wrote json configuration to '{str(helics_json_file)}'!"
 
@@ -39,7 +39,8 @@ def _get_json_data(json_file: pathlib.Path) -> dict[str, typing.Any]:
     with open(json_file, "r") as file:
         return json.load(file)
 
-def _deploy_config(json_data: dict[str, typing.Any], manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path) -> None:
+def _deploy_config(json_data: dict[str, typing.Any], manager: plugins.manager.PluginManager,
+                   install_root: pathlib.Path, deploy_root: pathlib.Path) -> pathlib.Path:
     # Validate that a total time has been set
     total_time_seconds = _validate_key_value(json_data, "total_time_seconds", float)
 
@@ -52,71 +53,69 @@ def _deploy_config(json_data: dict[str, typing.Any], manager: plugins.manager.Pl
     # Append cosim name to deploy root
     deploy_root = deploy_root / cosim_name
     deploy_root.mkdir(exist_ok=True)
+    cosim_def_path = deploy_root / "cosim_def.json"
 
     try:
         # Iterate over the components
         for component in components:
-            component["total_time_seconds"] = total_time_seconds
-            _iterate_components(component, manager, install_root, deploy_root)
+            _deploy_components(component, total_time_seconds, manager, install_root, deploy_root)
     finally:
+        # Do this in a finally to ensure we write out the info regardless of how we got here.
         # write cosim json file to deploy root
-        with open(deploy_root / "cosim_def.json", "w") as json_file:
+        with open(cosim_def_path, "w") as json_file:
             json.dump(json_data, json_file, indent=4)
 
-def _iterate_components(json_data: dict[str, typing.Any], manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path) -> None:
-    # If no type key is found within the component, assume it is a sub-component
-    # If the type is not recognized in the plugin names, assume it is a sub-component
-    plugin_name = _validate_key_value(json_data, "type", str, raise_error=False)
-    plugin = manager.get(plugin_name)
+    # Do not return within the finally clause, it may silence an exception
+    return cosim_def_path
 
-    if plugin:
-        plugin_options = _validate_key_value(json_data, "options", dict[str, typing.Any], raise_error=False)
-        plugin_options["total_time_seconds"] = json_data["total_time_seconds"]
-        plugin.deploy(plugin_options, str(deploy_root), str(install_root))
-
-    components = _validate_key_value(json_data, "components", list[dict[str, typing.Any]], raise_error=False)
-    for component in components:
-        component["total_time_seconds"] = json_data["total_time_seconds"]
-        _iterate_components(component, manager, install_root, deploy_root)
-
-def _write_helics_json(manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> pathlib.Path:
-    return pathlib.Path("")
-
-def _validate_key_value(json_dict: dict[str, typing.Any], key: str, expected_type: typing.Type[T], raise_error: bool = True) -> T:
+def _validate_key_value(json_dict: dict[str, typing.Any], key: str, expected_type: typing.Type[T]) -> T:
     value = expected_type()
 
-    # Check for raise error within the blocks to keep from attempting to access the key in the final
-    # if statement for when raise_error is false
     if not key in json_dict:
-        if raise_error:
-            raise ValueError(f"Key '{key}' not found!")
+        raise ValueError(f"Key '{key}' not found!")
     elif not isinstance(json_dict[key], expected_type):
-        if raise_error:
-            raise ValueError(f"Key {key} found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
+        raise ValueError(f"Key {key} found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
     else:
         value = json_dict[key]
 
     return value
 
-class _HelicsConfig:
-    def _validate_key_value(self, json_dict: dict[str, typing.Any], key: str, expected_type: typing.Type[T]) -> T:
-        value = expected_type()
+def _deploy_components(json_data: dict[str, typing.Any], total_time_seconds: float, manager: plugins.manager.PluginManager,
+                        install_root: pathlib.Path, deploy_root: pathlib.Path) -> None:
+    # If no type key is found within the component, assume it is a sub-component
+    # If the type is not recognized in the plugin names, assume it is a sub-component
+    plugin_name = _get_value_or_default(json_data, "type", str)
+    plugin = manager.get(plugin_name)
 
-        if not key in json_dict:
-            raise ValueError(f"Key '{key}' not found!")
-        elif not isinstance(json_dict[key], expected_type):
-            raise ValueError(f"Key {key} found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
-        else:
-            value = json_dict[key]
+    if plugin:
+        plugin_options = _get_value_or_default(json_data, "options", dict[str, typing.Any])
+        plugin.deploy(plugin_options, total_time_seconds, str(deploy_root), str(install_root))
 
-        return value
+    components = _get_value_or_default(json_data, "components", list[dict[str, typing.Any]])
+    for component in components:
+        _deploy_components(component, total_time_seconds, manager, install_root, deploy_root)
 
-    def __init__(self, json_config: dict[str, typing.Any]):
-        self.cosim_name: str = ""
-        self.total_time_seconds: float = 0.0
-        self.components: dict[str, typing.Any] = dict()
+def _get_value_or_default(json_dict: dict[str, typing.Any], key: str, expected_type: typing.Type[T]) -> T:
+    value = expected_type()
 
-        self.cosim_name = self._validate_key_value(json_config, "cosim_name", str)
-        self.total_time_seconds = self._validate_key_value(json_config, "total_time_seconds", float)
-        self.components = self._validate_key_value(json_config, "components", dict[str, typing.Any])
+    if key in json_dict and isinstance(json_dict[key], expected_type):
+        value = json_dict[key]
 
+    return value
+
+def _write_helics_json(cosim_def_file: pathlib.Path, manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> pathlib.Path:
+    cosim_def_data = _get_json_data(cosim_def_file)
+
+    cosim_name = cosim_def_data["cosim_name"]
+
+    helics_json_data = dict()
+    helics_json_data["name"] = cosim_name
+
+def _get_models(manager: plugins.manager.PluginManager, json_data: dict[str, typing.Any]) -> dict[str, list[str]]:
+    models = dict[str, list[str]]()
+
+    components = _get_value_or_default(json_data, "components", list[dict[str, typing.Any]])
+
+    return models
+
+def

--- a/deploy/commands/deploy_config.py
+++ b/deploy/commands/deploy_config.py
@@ -14,8 +14,9 @@ def deploy(manager: plugins.manager.PluginManager, install_root: pathlib.Path, d
     json_data = _get_json_data(json_file)
 
     cosim_def_file = _deploy_config(json_data, manager, install_root, deploy_root)
-    helics_json_data = _get_helics_json_data(_get_cosim_name(cosim_def_file), manager, deploy_root)
-    helics_json_file = cosim_def_file.parent / "helics_runner.json"
+    deploy_path = cosim_def_file.parent
+    helics_json_data = _get_helics_json_data(_get_cosim_name(cosim_def_file), manager, deploy_path)
+    helics_json_file = deploy_path / "helics_runner.json"
     _write_json(helics_json_data, helics_json_file)
 
     return f"Successfully deployed and wrote json configuration to '{str(helics_json_file)}'!"

--- a/deploy/commands/deploy_config.py
+++ b/deploy/commands/deploy_config.py
@@ -1,0 +1,44 @@
+import json
+import pathlib
+import typing
+
+import plugins.manager
+
+def deploy(manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path, json_file: pathlib.Path) -> str:
+    """:raises: ValueError if any paths do not exist or issues arise related to paths."""
+
+    _validate_input_paths(install_root, deploy_root, json_file)
+
+    json_data = _get_json_data(json_file)
+
+    _iterate_components(json_data, manager, install_root, deploy_root)
+    helics_json_file = _write_helics_json(manager, deploy_root)
+
+    return f"Successfully deployed and wrote json configuration to '{str(helics_json_file)}'!"
+
+def _validate_input_paths(install_root: pathlib.Path, deploy_root: pathlib.Path, json_file: pathlib.Path) -> None:
+    """:raises: ValueError if any paths do not exist, or if expected directories are actually files."""
+    if not install_root.exists():
+        raise ValueError(f"Given Install Root '{str(install_root)}' does not exist!")
+    elif install_root.is_file():
+        raise ValueError(f"Given Install Root '{str(install_root)}' is not a directory!")
+
+    try:
+        deploy_root.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise ValueError(f"Error when preparing Deploy Root '{str(deploy_root)}'! Exception: {e.strerror}")
+    if deploy_root.is_file():
+        raise ValueError(f"Given Deploy Root '{str(deploy_root)}' is not a directory!")
+
+    if not json_file.exists():
+        raise ValueError(f"Given Json File '{str(json_file)}' does not exist!")
+
+def _get_json_data(json_file: pathlib.Path) -> dict[str, typing.Any]:
+    with open(json_file, "r") as file:
+        return json.load(file)
+
+def _iterate_components(json_data: dict[str, typing.Any], manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path) -> None:
+    pass
+
+def _write_helics_json(manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> pathlib.Path:
+    return pathlib.Path("")

--- a/deploy/commands/deploy_config.py
+++ b/deploy/commands/deploy_config.py
@@ -4,6 +4,8 @@ import typing
 
 import plugins.manager
 
+T = typing.TypeVar("T")
+
 def deploy(manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path, json_file: pathlib.Path) -> str:
     """:raises: ValueError if any paths do not exist or issues arise related to paths."""
 
@@ -11,7 +13,7 @@ def deploy(manager: plugins.manager.PluginManager, install_root: pathlib.Path, d
 
     json_data = _get_json_data(json_file)
 
-    _iterate_components(json_data, manager, install_root, deploy_root)
+    _deploy_config(json_data, manager, install_root, deploy_root)
     helics_json_file = _write_helics_json(manager, deploy_root)
 
     return f"Successfully deployed and wrote json configuration to '{str(helics_json_file)}'!"
@@ -37,8 +39,84 @@ def _get_json_data(json_file: pathlib.Path) -> dict[str, typing.Any]:
     with open(json_file, "r") as file:
         return json.load(file)
 
+def _deploy_config(json_data: dict[str, typing.Any], manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path) -> None:
+    # Validate that a total time has been set
+    total_time_seconds = _validate_key_value(json_data, "total_time_seconds", float)
+
+    # Validate that a components key has been set
+    components = _validate_key_value(json_data, "components", list[dict[str, typing.Any]])
+
+    # Validate that a cosim name has been set
+    cosim_name = _validate_key_value(json_data, "cosim_name", str)
+
+    # Append cosim name to deploy root
+    deploy_root = deploy_root / cosim_name
+    deploy_root.mkdir(exist_ok=True)
+
+    try:
+        # Iterate over the components
+        for component in components:
+            component["total_time_seconds"] = total_time_seconds
+            _iterate_components(component, manager, install_root, deploy_root)
+    finally:
+        # write cosim json file to deploy root
+        with open(deploy_root / "cosim_def.json", "w") as json_file:
+            json.dump(json_data, json_file, indent=4)
+
 def _iterate_components(json_data: dict[str, typing.Any], manager: plugins.manager.PluginManager, install_root: pathlib.Path, deploy_root: pathlib.Path) -> None:
-    pass
+    # If no type key is found within the component, assume it is a sub-component
+    # If the type is not recognized in the plugin names, assume it is a sub-component
+    plugin_name = _validate_key_value(json_data, "type", str, raise_error=False)
+    plugin = manager.get(plugin_name)
+
+    if plugin:
+        plugin_options = _validate_key_value(json_data, "options", dict[str, typing.Any], raise_error=False)
+        plugin_options["total_time_seconds"] = json_data["total_time_seconds"]
+        plugin.deploy(plugin_options, str(deploy_root), str(install_root))
+
+    components = _validate_key_value(json_data, "components", list[dict[str, typing.Any]], raise_error=False)
+    for component in components:
+        component["total_time_seconds"] = json_data["total_time_seconds"]
+        _iterate_components(component, manager, install_root, deploy_root)
 
 def _write_helics_json(manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> pathlib.Path:
     return pathlib.Path("")
+
+def _validate_key_value(json_dict: dict[str, typing.Any], key: str, expected_type: typing.Type[T], raise_error: bool = True) -> T:
+    value = expected_type()
+
+    # Check for raise error within the blocks to keep from attempting to access the key in the final
+    # if statement for when raise_error is false
+    if not key in json_dict:
+        if raise_error:
+            raise ValueError(f"Key '{key}' not found!")
+    elif not isinstance(json_dict[key], expected_type):
+        if raise_error:
+            raise ValueError(f"Key {key} found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
+    else:
+        value = json_dict[key]
+
+    return value
+
+class _HelicsConfig:
+    def _validate_key_value(self, json_dict: dict[str, typing.Any], key: str, expected_type: typing.Type[T]) -> T:
+        value = expected_type()
+
+        if not key in json_dict:
+            raise ValueError(f"Key '{key}' not found!")
+        elif not isinstance(json_dict[key], expected_type):
+            raise ValueError(f"Key {key} found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
+        else:
+            value = json_dict[key]
+
+        return value
+
+    def __init__(self, json_config: dict[str, typing.Any]):
+        self.cosim_name: str = ""
+        self.total_time_seconds: float = 0.0
+        self.components: dict[str, typing.Any] = dict()
+
+        self.cosim_name = self._validate_key_value(json_config, "cosim_name", str)
+        self.total_time_seconds = self._validate_key_value(json_config, "total_time_seconds", float)
+        self.components = self._validate_key_value(json_config, "components", dict[str, typing.Any])
+

--- a/deploy/commands/deploy_config.py
+++ b/deploy/commands/deploy_config.py
@@ -14,7 +14,9 @@ def deploy(manager: plugins.manager.PluginManager, install_root: pathlib.Path, d
     json_data = _get_json_data(json_file)
 
     cosim_def_file = _deploy_config(json_data, manager, install_root, deploy_root)
-    helics_json_file = _write_helics_json(cosim_def_file, manager, deploy_root)
+    helics_json_data = _get_helics_json_data(_get_cosim_name(cosim_def_file), manager, deploy_root)
+    helics_json_file = cosim_def_file.parent / "helics_runner.json"
+    _write_json(helics_json_data, helics_json_file)
 
     return f"Successfully deployed and wrote json configuration to '{str(helics_json_file)}'!"
 
@@ -28,7 +30,7 @@ def _validate_input_paths(install_root: pathlib.Path, deploy_root: pathlib.Path,
     try:
         deploy_root.mkdir(parents=True, exist_ok=True)
     except OSError as e:
-        raise ValueError(f"Error when preparing Deploy Root '{str(deploy_root)}'! Exception: {e.strerror}")
+        raise ValueError(f"Error when preparing Deploy Root '{str(deploy_root)}'! Exception: {str(e)}")
     if deploy_root.is_file():
         raise ValueError(f"Given Deploy Root '{str(deploy_root)}' is not a directory!")
 
@@ -45,7 +47,7 @@ def _deploy_config(json_data: dict[str, typing.Any], manager: plugins.manager.Pl
     total_time_seconds = _validate_key_value(json_data, "total_time_seconds", float)
 
     # Validate that a components key has been set
-    components = _validate_key_value(json_data, "components", list[dict[str, typing.Any]])
+    components = _validate_key_value(json_data, "components", list)
 
     # Validate that a cosim name has been set
     cosim_name = _validate_key_value(json_data, "cosim_name", str)
@@ -62,8 +64,7 @@ def _deploy_config(json_data: dict[str, typing.Any], manager: plugins.manager.Pl
     finally:
         # Do this in a finally to ensure we write out the info regardless of how we got here.
         # write cosim json file to deploy root
-        with open(cosim_def_path, "w") as json_file:
-            json.dump(json_data, json_file, indent=4)
+        _write_json(json_data, cosim_def_path)
 
     # Do not return within the finally clause, it may silence an exception
     return cosim_def_path
@@ -74,7 +75,7 @@ def _validate_key_value(json_dict: dict[str, typing.Any], key: str, expected_typ
     if not key in json_dict:
         raise ValueError(f"Key '{key}' not found!")
     elif not isinstance(json_dict[key], expected_type):
-        raise ValueError(f"Key {key} found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
+        raise ValueError(f"Key '{key}' found, but the type is incorrect. Expected '{expected_type.__name__}', Actual: '{type(json_dict[key]).__name__}'")
     else:
         value = json_dict[key]
 
@@ -88,10 +89,10 @@ def _deploy_components(json_data: dict[str, typing.Any], total_time_seconds: flo
     plugin = manager.get(plugin_name)
 
     if plugin:
-        plugin_options = _get_value_or_default(json_data, "options", dict[str, typing.Any])
+        plugin_options = _get_value_or_default(json_data, "options", dict)
         plugin.deploy(plugin_options, total_time_seconds, str(deploy_root), str(install_root))
 
-    components = _get_value_or_default(json_data, "components", list[dict[str, typing.Any]])
+    components = _get_value_or_default(json_data, "components", list)
     for component in components:
         _deploy_components(component, total_time_seconds, manager, install_root, deploy_root)
 
@@ -103,15 +104,16 @@ def _get_value_or_default(json_dict: dict[str, typing.Any], key: str, expected_t
 
     return value
 
-def _write_helics_json(cosim_def_file: pathlib.Path, manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> pathlib.Path:
+def _get_cosim_name(cosim_def_file: pathlib.Path) -> str:
     # Get cosim name
     cosim_def_data = _get_json_data(cosim_def_file)
-    cosim_name = cosim_def_data["cosim_name"]
+    return cosim_def_data["cosim_name"]
 
+def _get_model_execs(manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> list[dict[str, str]]:
     # Initialize the federates
     federates = list[dict[str, str]]()
     models = _get_models(manager, deploy_root)
-    for plugin_name, model_names in models:
+    for plugin_name, model_names in models.items():
         plugin = manager.get(plugin_name)
         if not plugin:
             continue # this should never happen
@@ -120,7 +122,7 @@ def _write_helics_json(cosim_def_file: pathlib.Path, manager: plugins.manager.Pl
             federates.append(plugin.get_exec_json(model_name, str(deploy_root)))
 
     # Setup the broker
-    federate_count = len(models)
+    federate_count = len(federates)
     broker_federate = {
         "directory": ".",
         "exec": f"helics-broker --federates={federate_count} --port 23500",
@@ -129,17 +131,19 @@ def _write_helics_json(cosim_def_file: pathlib.Path, manager: plugins.manager.Pl
     }
     federates.insert(0, broker_federate)
 
+    return federates
+
+def _get_helics_json_data(cosim_name: str, manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> dict[str, typing.Any]:
     # Setup helics json
     helics_json_data = dict()
     helics_json_data["name"] = cosim_name
-    helics_json_data["federates"] = federates
+    helics_json_data["federates"] = _get_model_execs(manager, deploy_root)
 
-    # Write helics json data to the cosim directory
-    helics_runner_file = cosim_def_file.parent / "helics_runner.json"
-    with open(helics_runner_file, "w") as json_file:
-        json.dump(helics_json_data, json_file, indent=4)
+    return helics_json_data
 
-    return helics_runner_file
+def _write_json(json_data: dict[str, typing.Any], json_path: pathlib.Path) -> None:
+    with open(json_path, "w") as json_file:
+        json.dump(json_data, json_file, indent=4)
 
 def _get_models(manager: plugins.manager.PluginManager, deploy_root: pathlib.Path) -> dict[str, list[str]]:
     models = dict[str, list[str]]()

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -4,6 +4,7 @@ import commands.list_names
 import commands.get_federate_definition
 import commands.list_source_files
 import commands.list_model_files
+import commands.deploy_config
 import pathlib
 import plugins.manager as manager
 
@@ -15,6 +16,7 @@ def main():
     _setup_get_exec_parser(subparsers)
     _setup_list_source_files_parser(subparsers)
     _setup_list_model_files_parser(subparsers)
+    _setup_deploy_parser(subparsers)
 
     args = top_parser.parse_args()
 
@@ -26,11 +28,13 @@ def main():
         if args.command == "list-names":
             _print_plugin_names(plugin_manager)
         elif args.command == "get-exec":
-            _print_federate_definition(plugin_manager, args.plugin_name, args.model_name, pathlib.Path(args.deploy_root))
+            _print_federate_definition(plugin_manager, args.plugin_name, args.model_name, args.deploy_root)
         elif args.command == "list-source-files":
-            _print_list_source_files(plugin_manager, args.plugin_name, pathlib.Path(args.install_dir))
+            _print_list_source_files(plugin_manager, args.plugin_name, args.install_dir)
         elif args.command == "list-model-files":
-            _print_list_model_files(plugin_manager, args.model_name, pathlib.Path(args.deploy_dir), args.plugin_name)
+            _print_list_model_files(plugin_manager, args.model_name, args.deploy_dir, args.plugin_name)
+        elif args.command == "deploy":
+            _print_deploy_parser(plugin_manager, args.install_dir, args.deploy_dir, args.config)
         else:
             print(f"Unrecognized Command '{args.command}', terminating.")
 
@@ -50,7 +54,7 @@ def _print_plugin_names(plugin_manager: manager.PluginManager) -> None:
 def _setup_get_exec_parser(subparser: argparse._SubParsersAction) -> None:
     get_exec_parser = subparser.add_parser("get-exec", help="Attempts to find a specific model-name within a given deployed directory")
     get_exec_parser.add_argument("--model-name", required=True, help="The name of the model to find", type=str)
-    get_exec_parser.add_argument("--deploy-root", required=True, help="The deploy directory to search within", type=str)
+    get_exec_parser.add_argument("--deploy-root", required=True, help="The deploy directory to search within", type=pathlib.Path)
     get_exec_parser.add_argument("--plugin-name", required=False, help="(Optional) The name of the plugin that is expected to contain the name.", type=str, default="")
 
 def _print_federate_definition(plugin_manager: manager.PluginManager, plugin_name: str, model_name: str, deploy_root: pathlib.Path) -> None:
@@ -60,9 +64,8 @@ def _print_federate_definition(plugin_manager: manager.PluginManager, plugin_nam
 def _setup_list_source_files_parser(subparser: argparse._SubParsersAction) -> None:
     list_source_files_parser = subparser.add_parser("list-source-files", help="Attempts to list the given source files for a plugin "
                                                     + "located within the install directory")
-
     list_source_files_parser.add_argument("--plugin-name", required=True, help="The name of the plugin to get input files for", type=str)
-    list_source_files_parser.add_argument("--install-dir", required=True, help="The path to the install directory to read from", type=str)
+    list_source_files_parser.add_argument("--install-dir", required=True, help="The path to the install directory to read from", type=pathlib.Path)
 
 def _print_list_source_files(plugin_manager: manager.PluginManager, plugin_name: str, install_dir: pathlib.Path) -> None:
     print(f"Source Files for {plugin_name}")
@@ -71,14 +74,23 @@ def _print_list_source_files(plugin_manager: manager.PluginManager, plugin_name:
 def _setup_list_model_files_parser(subparser: argparse._SubParsersAction) -> None:
     list_model_files_parser = subparser.add_parser("list-model-files", help="Attempts to list the given model files for a plugin and model name "
                                                    + "located within the deploy directory")
-
     list_model_files_parser.add_argument("--model-name", required=True, help="The name of the model to get input files for", type=str)
-    list_model_files_parser.add_argument("--deploy-dir", required=True, help="The path to the deploy directory to read from", type=str)
+    list_model_files_parser.add_argument("--deploy-dir", required=True, help="The path to the deploy directory to read from", type=pathlib.Path)
     list_model_files_parser.add_argument("--plugin-name", required=False, help="The name of the plugin to search from to find the model's input files", type=str)
 
 def _print_list_model_files(plugin_manager: manager.PluginManager, model_name: str, deploy_dir: pathlib.Path, plugin_name: str) -> None:
     print(f"Model Files for {model_name}")
     print(commands.list_model_files.get_model_files(plugin_manager, model_name, deploy_dir, plugin_name))
+
+def _setup_deploy_parser(subparser: argparse._SubParsersAction) -> None:
+    deploy_parser = subparser.add_parser("deploy", help="Attempts to deploy a given configuration to a given directory.")
+    deploy_parser.add_argument("--install-dir", required=True, help="The path to the install directory to read from", type=pathlib.Path)
+    deploy_parser.add_argument("--deploy-dir", required=True, help="The path to the deploy directory to read from", type=pathlib.Path)
+    deploy_parser.add_argument("--config", required=True, help="The path to the input Json configuration", type=pathlib.Path)
+
+def _print_deploy_parser(plugin_manager: manager.PluginManager, install_dir: pathlib.Path, deploy_dir: pathlib.Path, json_file: pathlib.Path) -> None:
+    print(f"Deploy Configuration to '{str(deploy_dir)}'")
+    print(commands.deploy_config.deploy(plugin_manager, install_dir, deploy_dir, json_file))
 
 if __name__ == '__main__':
     main()

--- a/deploy/deploy.py
+++ b/deploy/deploy.py
@@ -30,15 +30,15 @@ def main():
         if args.command == "list-names":
             _print_plugin_names(plugin_manager)
         elif args.command == "get-exec":
-            _print_federate_definition(plugin_manager, args.plugin_name, args.model_name, args.deploy_root)
+            _print_federate_definition(plugin_manager, args.plugin_name, args.model_name, args.deploy_root.resolve())
         elif args.command == "list-source-files":
-            _print_list_source_files(plugin_manager, args.plugin_name, args.install_dir)
+            _print_list_source_files(plugin_manager, args.plugin_name, args.install_dir.resolve())
         elif args.command == "list-model-files":
-            _print_list_model_files(plugin_manager, args.model_name, args.deploy_dir, args.plugin_name)
+            _print_list_model_files(plugin_manager, args.model_name, args.deploy_dir.resolve(), args.plugin_name)
         elif args.command == "list-model-names":
-            _print_list_model_names(plugin_manager, args.deploy_dir, args.plugin_name)
+            _print_list_model_names(plugin_manager, args.deploy_dir.resolve(), args.plugin_name)
         elif args.command == "deploy":
-            _print_deploy_parser(plugin_manager, args.install_dir, args.deploy_dir, args.config)
+            _print_deploy_parser(plugin_manager, args.install_dir.resolve(), args.deploy_dir.resolve(), args.config.resolve())
         else:
             print(f"Unrecognized Command '{args.command}', terminating.")
 

--- a/deploy/tests/test_deploy_config.py
+++ b/deploy/tests/test_deploy_config.py
@@ -1,0 +1,328 @@
+import pathlib
+import json
+import typing
+import unittest.mock as mock
+
+import commands.deploy_config as deploy
+import tests.tools.base_plugin_manager_test_case as base_test
+
+def _expected_models() -> dict[str, list[str]]:
+    return {
+        "mock_plugin_a/interface": ["model_plugin_a", "model_plugin_a_sub1"],
+        "mock_plugin_b/interface": ["model_plugin_b"]
+    }
+
+def _expected_federates() -> list[dict[str, str]]:
+    return [
+        {
+            "directory": ".",
+            "exec": "helics-broker --federates=3 --port 23500",
+            "host": "localhost",
+            "name": "main_broker"
+        },
+        {
+            "directory": ".",
+            "exec": "./mock_plugin_a",
+            "host": "localhost",
+            "name": "mock_plugin_a"
+        },
+        {
+            "directory": ".",
+            "exec": "./model_plugin_a_sub1",
+            "host": "localhost",
+            "name": "model_plugin_a_sub1"
+        },
+        {
+            "directory": ".",
+            "exec": "./mock_plugin_b",
+            "host": "localhost",
+            "name": "mock_plugin_b"
+        }
+    ]
+
+def _expected_helics_json() -> dict[str, typing.Any]:
+    return {
+        "name": "cosim_test",
+        "federates": _expected_federates()
+    }
+
+def _baseline_components() -> dict[str, typing.Any]:
+    return {
+        "type": "component",
+        "components": [
+            {
+                "type": "mock_plugin_a/interface",
+                "options": { }
+            },
+            {
+                "type": "component",
+                "components": [
+                    {
+                        "type": "mock_plugin_b/interface",
+                        "options": { }
+                    }
+                ]
+            }
+        ]
+    }
+
+def _expected_components() -> dict[str, typing.Any]:
+    components = _baseline_components()
+    mock_a_opts = components["components"][0]["options"]
+    mock_a_opts["deploy"] = True
+
+    mock_b_opts = components["components"][1]["components"][0]["options"]
+    mock_b_opts["deploy"] = True
+
+    return components
+
+def _baseline_deploy_config() -> dict[str, typing.Any]:
+    return {
+        "cosim_name": "cosim_test",
+        "total_time_seconds": 100.0,
+        "components": [ _baseline_components() ]
+    }
+
+def _expected_deploy_config() -> dict[str, typing.Any]:
+    deploy_config = _baseline_deploy_config()
+    deploy_config["components"][0] = _expected_components()
+
+    return deploy_config
+
+def _get_basic_json() -> dict[str, str]:
+    return { "key": "value" }
+
+def _get_mock_path() -> mock.MagicMock:
+    mock_path = mock.MagicMock(spec=pathlib.Path)
+    mock_path.__str__.return_value = "fake_path"
+    mock_path.exists.return_value = True
+    return mock_path
+
+def _append_mock_path(path_str: str) -> mock.MagicMock:
+    """Creates a mock path that supports infinite chaining and .parent."""
+    mock_path = mock.MagicMock(spec=pathlib.Path)
+    mock_path.__str__.return_value = path_str
+
+    def join_paths(other):
+        # Create the child mock
+        child_path = f"{path_str}/{other}"
+        child_mock = _append_mock_path(child_path)
+        # Link the child's .parent back to THIS mock instance
+        child_mock.parent = mock_path
+        return child_mock
+
+    # Handle / operator
+    mock_path.__truediv__.side_effect = join_paths
+    mock_path.exists.return_value = True
+    mock_path.mkdir.return_value = None
+    return mock_path
+
+def _get_mock_deploy_path() -> mock.MagicMock:
+    mock_deploy = _append_mock_path("fake_deploy_path")
+    mock_deploy.is_file.return_value = False
+    return mock_deploy
+
+def _get_mock_install_path() -> mock.MagicMock:
+    mock_install = mock.MagicMock(spec=pathlib.Path)
+    mock_install.__str__.return_value = "fake_install_path"
+    mock_install.exists.return_value = True
+    mock_install.is_file.return_value = False
+    return mock_install
+
+def _get_mock_json_path() -> mock.MagicMock:
+    mock_json = mock.MagicMock(spec=pathlib.Path)
+    mock_json.__str__.return_value = "fake_json_file"
+    mock_json.exists.return_value = True
+    return mock_json
+
+class TestDeployConfig(base_test.BaseTestPluginManager):
+    def test_get_models(self):
+        actual = deploy._get_models(self.manager, _get_mock_path())
+        self.assertDictEqual(_expected_models(), actual)
+
+    def test_get_helics_json_data(self):
+        actual = deploy._get_helics_json_data("cosim_test", self.manager, _get_mock_path())
+        self.maxDiff = None # Use this because errors need it to display the diff
+        self.assertDictEqual(_expected_helics_json(), actual)
+
+    def test_get_model_execs(self):
+        actual = deploy._get_model_execs(self.manager, _get_mock_path())
+        self.assertCountEqual(_expected_federates(), actual)
+
+    def test_get_cosim_name(self):
+        with mock.patch.object(deploy, "_get_json_data") as mock_func:
+            mock_func.return_value = { "cosim_name": "cosim_test" }
+            actual = deploy._get_cosim_name(_get_mock_path())
+        self.assertEqual("cosim_test", actual)
+
+    def test_get_value_or_default_success(self):
+        actual = deploy._get_value_or_default(_get_basic_json(), "key", str)
+        self.assertEqual("value", actual)
+
+    def test_get_value_or_default_bad_key(self):
+        actual = deploy._get_value_or_default(_get_basic_json(), "key1", str)
+        self.assertEqual("", actual)
+
+    def test_get_value_or_default_bad_type(self):
+        actual = deploy._get_value_or_default(_get_basic_json(), "key", float)
+        self.assertEqual(0.0, actual)
+
+    def test_validate_key_value_success(self):
+        actual = deploy._validate_key_value(_get_basic_json(), "key", str)
+        self.assertEqual("value", actual)
+
+    def test_validate_key_value_bad_key(self):
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_key_value(_get_basic_json(), "key1", str)
+
+        self.assertEqual("Key 'key1' not found!", str(err.exception))
+
+    def test_validate_key_value_bad_type(self):
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_key_value(_get_basic_json(), "key", float)
+
+        expecected = "Key 'key' found, but the type is incorrect. Expected 'float', Actual: 'str'"
+        self.assertEqual(expecected, str(err.exception))
+
+    def test_deploy_components(self):
+        actual = _baseline_components()
+        deploy._deploy_components(actual, 0.0, self.manager, _get_mock_install_path(), _get_mock_deploy_path())
+
+        expected = _expected_components()
+
+        self.assertDictEqual(expected, actual)
+
+    def test_deploy_config_success(self):
+        actual = _baseline_deploy_config()
+        with mock.patch.object(deploy, "_write_json") as mock_func:
+            mock_func.return_value = None
+            cosim_defintion_path = deploy._deploy_config(actual, self.manager, _get_mock_install_path(), _get_mock_deploy_path())
+
+        self.assertDictEqual(_expected_deploy_config(), actual)
+        expected_path = pathlib.Path("fake_deploy_path", "cosim_test", "cosim_def.json")
+        self.assertEqual(str(expected_path), str(cosim_defintion_path))
+
+    def test_deploy_config_missing_fields(self):
+        mock_install = _get_mock_install_path()
+        mock_deploy = _get_mock_deploy_path()
+
+        errors = list[str]()
+        missing_time_data = {"cosim_name": "test", "components": [{}]}
+        missing_name_data = {"components": [{}], "total_time_seconds": 0.0}
+        missing_component_data = {"cosim_name": "test", "total_time_seconds": 0.0}
+
+        with mock.patch.object(deploy, "_write_json") as mock_func:
+            mock_func.return_value = None
+            try:
+                deploy._deploy_config(missing_time_data, self.manager, mock_install, mock_deploy)
+                errors.append("Should have thrown exception with missing key 'total_time_seconds'")
+            except ValueError:
+                pass
+
+            try:
+                deploy._deploy_config(missing_name_data, self.manager, mock_install, mock_deploy)
+                errors.append("Should have thrown exception with missing key 'cosim_name'")
+            except ValueError:
+                pass
+
+            try:
+                deploy._deploy_config(missing_component_data, self.manager, mock_install, mock_deploy)
+                errors.append("Should have thrown exception with missing key 'components'")
+            except ValueError:
+                pass
+
+        self.assertFalse(errors, "\n".join(errors))
+
+    def test_validate_input_paths_success(self):
+        mock_install = _get_mock_install_path()
+        mock_deploy = _get_mock_deploy_path()
+        mock_json = _get_mock_json_path()
+
+        try:
+            deploy._validate_input_paths(mock_install, mock_deploy, mock_json)
+        except ValueError as e:
+            self.fail(f"my_function() raised error unexpectedly!\nError:{str(e)}")
+
+    def test_validate_input_paths_install_does_not_exist(self):
+        mock_install = _get_mock_install_path()
+        mock_install.exists.return_value = False
+        mock_deploy = _get_mock_deploy_path()
+        mock_json = _get_mock_json_path()
+
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_input_paths(mock_install, mock_deploy, mock_json)
+
+        expected = "Given Install Root 'fake_install_path' does not exist!"
+        self.assertEqual(expected, str(err.exception))
+
+    def test_validate_input_paths_install_is_file(self):
+        mock_install = _get_mock_install_path()
+        mock_install.is_file.return_value = True
+        mock_deploy = _get_mock_deploy_path()
+        mock_json = _get_mock_json_path()
+
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_input_paths(mock_install, mock_deploy, mock_json)
+
+        expected = "Given Install Root 'fake_install_path' is not a directory!"
+        self.assertEqual(expected, str(err.exception))
+
+    def test_validate_input_paths_deploy_mkdir_raises_error(self):
+        mock_install = _get_mock_install_path()
+        mock_deploy = _get_mock_deploy_path()
+        mock_deploy.mkdir.side_effect = OSError("mocked error")
+        mock_json = _get_mock_json_path()
+
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_input_paths(mock_install, mock_deploy, mock_json)
+
+        expected = "Error when preparing Deploy Root 'fake_deploy_path'! Exception: mocked error"
+        self.assertEqual(expected, str(err.exception))
+
+    def test_validate_input_paths_deploy_is_file(self):
+        mock_install = _get_mock_install_path()
+        mock_deploy = _get_mock_deploy_path()
+        mock_deploy.is_file.return_value = True
+        mock_json = _get_mock_json_path()
+
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_input_paths(mock_install, mock_deploy, mock_json)
+
+        expected = "Given Deploy Root 'fake_deploy_path' is not a directory!"
+        self.assertEqual(expected, str(err.exception))
+
+    def test_validate_input_paths_json_does_not_exist(self):
+        mock_install = _get_mock_install_path()
+        mock_deploy = _get_mock_deploy_path()
+        mock_json = _get_mock_json_path()
+        mock_json.exists.return_value = False
+
+        with self.assertRaises(ValueError) as err:
+            deploy._validate_input_paths(mock_install, mock_deploy, mock_json)
+
+        expected = "Given Json File 'fake_json_file' does not exist!"
+        self.assertEqual(expected, str(err.exception))
+
+    def test_deploy(self):
+        mock_install = _get_mock_install_path()
+        mock_deploy = _get_mock_deploy_path()
+        mock_json = _get_mock_json_path()
+
+        with (
+            mock.patch.object(deploy, "_get_json_data") as mock_get_json,
+            mock.patch.object(deploy, "_deploy_config", wraps=deploy._deploy_config) as wrapped_deploy_config,
+            mock.patch.object(deploy, "_write_json") as mock_write_json
+        ):
+            mock_get_json.return_value = _baseline_deploy_config()
+            mock_write_json.return_value = None
+
+            actual_message = deploy.deploy(self.manager, mock_install, mock_deploy, mock_json)
+            deploy_args, _ = wrapped_deploy_config.call_args
+            actual_deploy_data, _, _, _ = deploy_args
+            write_args, _ = mock_write_json.call_args
+            actual_helics_data, _ = write_args
+
+        self.assertDictEqual(_expected_deploy_config(), actual_deploy_data)
+        self.assertDictEqual(_expected_helics_json(), actual_helics_data)
+        expected_message = "Successfully deployed and wrote json configuration to 'fake_deploy_path/cosim_test/helics_runner.json'!"
+        self.assertEqual(expected_message, actual_message)

--- a/deploy/tests/test_deploy_config.py
+++ b/deploy/tests/test_deploy_config.py
@@ -1,5 +1,4 @@
 import pathlib
-import json
 import typing
 import unittest.mock as mock
 

--- a/deploy/tests/tools/base_plugin_manager_test_case.py
+++ b/deploy/tests/tools/base_plugin_manager_test_case.py
@@ -7,8 +7,8 @@ import plugins.manager
 import plugins.interface
 
 class MockPluginA(plugins.interface.IDeployable):
-    def deploy(self, json_config: dict, deploy_root: str, install_root: str):
-        pass
+    def deploy(self, json_config: dict, total_time_seconds: float, deploy_root: str, install_root: str):
+        json_config["deploy"] = True
 
     def get_baseline_files(self, install_root: str) -> list[str]:
         return [str(pathlib.Path(install_root, "mock_plugin_a")), str(pathlib.Path(install_root, "file_2"))]
@@ -30,6 +30,13 @@ class MockPluginA(plugins.interface.IDeployable):
                 "host": "localhost",
                 "name": "mock_plugin_a"
             }
+        elif model_name == "model_plugin_a_sub1":
+            return {
+                "directory": ".",
+                "exec": "./model_plugin_a_sub1",
+                "host": "localhost",
+                "name": "model_plugin_a_sub1"
+            }
         else:
             return dict[str, str]()
 
@@ -40,8 +47,8 @@ class MockPluginA(plugins.interface.IDeployable):
         return ["model_plugin_a", "model_plugin_a_sub1"]
 
 class MockPluginB(plugins.interface.IDeployable):
-    def deploy(self, json_config: dict, deploy_root: str, install_root: str):
-        pass
+    def deploy(self, json_config: dict, total_time_seconds: float, deploy_root: str, install_root: str):
+        json_config["deploy"] = True
 
     def get_baseline_files(self, install_root: str) -> list[str]:
         return [str(pathlib.Path(install_root, "mock_plugin_b"))]


### PR DESCRIPTION
You can run the unit tests to ensure they pass, but you can also run it manually with the debug_tools federate. A minimum example deployable cosim json is as follows:

```json
{
    "cosim_name": "manual_test",
    "total_time_seconds": 60.0,
    "components": [
        {
            "type": "debug_tools/dummy_federate",
            "options": {
                "name": "debug_tool_1",
                "local_log_file": "logs/debug_tool_1.log",
                "core_init": "",
                "core_type": "mpi"
            },
            "components": []
        }
    ]
}
```

This should deploy a single dummy federate to a location following the deploy command. I think it is highly worthwhile to manually deploy it once at least.

Side note: this leads to an odd syntax where we deploy by calling `python -m deploy deploy <flags>` I think I should rename the main module, but I am not sure what to call it. I will look up to see if I can group all the subcommands with a silent "category".